### PR TITLE
Fix min_length parameter in clean_ones function

### DIFF
--- a/FlyHigherCodes/BehaviorScoringFunctions.py
+++ b/FlyHigherCodes/BehaviorScoringFunctions.py
@@ -167,7 +167,7 @@ def clean_ones(df, column, min_length):
     # Loop through the array and clean isolated ones based on min_length criteria
     for i in range(n - min_length - 1):
         if x[i] == 0 and x[i + 1] == 1:
-            if x[i + 1: i + 1 + min_length + 1].sum() < 3:
+            if x[i + 1: i + 1 + min_length + 1].sum() < min_length:
                 x[i + 1] = 0
     df[column] = x
 


### PR DESCRIPTION
## Summary
- ensure `clean_ones` uses the provided `min_length` threshold rather than a fixed constant

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc5edd68c832b9285f10b71f395c5